### PR TITLE
fix a problem where NetworkError didn't contain underlying error

### DIFF
--- a/scripts/src/errors.ts
+++ b/scripts/src/errors.ts
@@ -92,7 +92,7 @@ export class AccountNotFoundError extends HorizonError {
 export class NetworkError extends Error implements KinSdkError {
 	readonly type = 'NetworkError';
 
-		constructor(readonly error?: any) {
+	constructor(readonly error: any) {
 		super( error && error.message ? error.message : `Network error occurred`);
 		this.error = error;
 	}
@@ -217,7 +217,7 @@ export class ErrorDecoder {
 			}
 		}
 
-		return new NetworkError();
+		return new NetworkError(errorBody);
 	}
 
 	static translateOperationError(errorCode: number, errorBody?: any): HorizonError {

--- a/scripts/src/friendbot.ts
+++ b/scripts/src/friendbot.ts
@@ -23,7 +23,7 @@ export class Friendbot {
 			if (e.response) {
 				response = e.response;
 			} else {
-				throw new NetworkError(e.message);
+				throw new NetworkError(e);
 			}
 		}
 

--- a/tests/src/blockchainInfoRetriever.unit.test.ts
+++ b/tests/src/blockchainInfoRetriever.unit.test.ts
@@ -1,6 +1,6 @@
 import * as nock from "nock";
 import {BlockchainInfoRetriever} from "../../scripts/src/blockchain/blockchainInfoRetriever";
-import {ResourceNotFoundError} from "../../scripts/src/errors";
+import {NetworkError, ResourceNotFoundError} from "../../scripts/src/errors";
 import {Server} from "@kinecosystem/kin-sdk";
 
 const fakeUrl = "https://horizon-testnet.kininfrastructure.com";
@@ -96,7 +96,7 @@ describe("BlockchainInfoRetriever.getMinimumFee", async () => {
 			.replyWithError({code: 'ETIMEDOUT'});
 
 		await expect(blockchainInfoRetriever.getMinimumFee())
-			.rejects.toHaveProperty('type', 'NetworkError');
+			.rejects.toEqual(new NetworkError({code: 'ETIMEDOUT'}));
 	});
 
 });

--- a/tests/src/friendbot.unit.test.ts
+++ b/tests/src/friendbot.unit.test.ts
@@ -1,7 +1,7 @@
 import {IAccountDataRetriever} from "../../scripts/src/blockchain/accountDataRetriever";
 import {Friendbot} from "../../scripts/src/friendbot";
 import * as nock from "nock";
-import {FriendbotError, InvalidAddressError, NetworkError} from "../../scripts/src/errors";
+import {FriendbotError, InvalidAddressError, NetworkError} from "../../scripts/src";
 
 const fakeUrl = "http://horizon.com";
 const publicAddress = "GDAVCZIOYRGV74ROE344CMRLPZYSZVRHNTRFGOUSAQBILJ7M5ES25KOZ";
@@ -104,7 +104,7 @@ describe("Friendbot.createOrFund", async () => {
 
 		isAccountExistingFn.mockResolvedValue(false);
 		await expect(friendBot.createOrFund(publicAddress, 30))
-			.rejects.toEqual(new NetworkError());
+			.rejects.toEqual(new NetworkError(errorResponseData));
 	});
 
 

--- a/tests/src/transactionRetrieverTest_fetchTransactionHistory.unit.test.ts
+++ b/tests/src/transactionRetrieverTest_fetchTransactionHistory.unit.test.ts
@@ -1,7 +1,7 @@
 import {TransactionRetriever} from "../../scripts/src/blockchain/transactionRetriever";
 import * as nock from "nock";
 import {CreateAccountTransaction, PaymentTransaction, RawTransaction} from "../../scripts/src/blockchain/horizonModels";
-import {ErrorResponse, InternalError, ResourceNotFoundError} from "../../scripts/src/errors";
+import {ErrorResponse, InternalError, NetworkError, ResourceNotFoundError} from "../../scripts/src/errors";
 import {Memo, Operation} from "@kinecosystem/kin-base";
 import {Server} from "@kinecosystem/kin-sdk";
 
@@ -284,9 +284,9 @@ describe("TransactionRetriever.fetchTransactionHistory", async () => {
 		const address = "GA66MWLBBBWVDQZFPDMZPJUODUUOZLGUPCXMPR7HNTGHX7VYAMY243RR";
 		nock(fakeUrl)
 			.get(url => url.includes(address))
-			.replyWithError({code: 'scripts/src'});
+			.replyWithError({code: 'ETIMEDOUT'});
 		await expect(transactionRetriever.fetchTransactionHistory({address: address}))
-			.rejects.toHaveProperty('type', 'NetworkError');
+			.rejects.toEqual(new NetworkError({code: 'ETIMEDOUT'}));
 	});
 
 });


### PR DESCRIPTION


#### Main purpose (bug/feature/enhancement + description)
Fix a problem where NetworkError didn't contain underlying error

#### Technical details
ErrorDecoder - instantiate NetworkError with the underlying error.
FriendBot - pass entire error instead of message only.
This fix is following a fix in js-kin-sdk in this pr https://github.com/kinecosystem/js-kin-sdk/pull/7, handleNetwork inside CallBuilder was hide general errors.
#### Tests (Unit/Integ)
Tests - check exact error object instead of type only
#### Documentation (Source/readme.md)
N/A