### PR TITLE
DP-552, DP-722, DP-533 - whitelistTransaction API enhancement, AccountNotFoundError with build transaction

### DIFF
--- a/scripts/src/errors.ts
+++ b/scripts/src/errors.ts
@@ -84,7 +84,7 @@ export class AccountNotFoundError extends HorizonError {
 	readonly type: ErrorType = 'AccountNotFoundError';
 
 	constructor(readonly errorBody: ErrorResponse, readonly title?: string) {
-		super(`Account was not found in the network.`, errorBody, title);
+		super(`Account was not found in the network`, errorBody, title);
 		this.errorCode = 404;
 	}
 }

--- a/scripts/src/kinAccount.ts
+++ b/scripts/src/kinAccount.ts
@@ -65,7 +65,7 @@ export class KinAccount {
 		return await this._txSender.submitTransaction(transactionBuilder);
 	}
 
-	whitelistTransaction(payload: string | WhitelistPayload): string {
+	whitelistTransaction(payload: WhitelistPayload): string {
 		return this._txSender.whitelistTransaction(payload);
 	}
 }

--- a/scripts/src/types.ts
+++ b/scripts/src/types.ts
@@ -1,6 +1,13 @@
 export type Address = string;
 export type TransactionId = string;
-export interface WhitelistPayload {
-	envelope: string,
-	networkId: string
-}
+
+export type WhitelistPayload =
+	{
+		envelope: string,
+		// backward compatibility, network_id is the correct one and aligns with python sdk
+		networkId: string
+	} |
+	{
+		envelope: string,
+		network_id: string
+	};


### PR DESCRIPTION
#### Main purpose (bug/feature/enhancement + description)
API enhancements of `KinAccount.whitelistTransaction` and `KinAccount.buildXXX`.
will solve https://github.com/kinecosystem/kin-sdk-node/issues/42
#### Technical details
* whitelistTransaction now accept both networkId and network_id as param,
in order to align to python sdk while keep backward compatibility,
using string is not allowed anymore as it wasn't clear anyway, and docs instruct to
use param object.
the type "envelop" also removed as it wasn't used, android already fixed it
and it was specific to tests whitelist service that anyway uses python code.
* Build account when account doesn't exist will yield an AccountNotFoundError
instead of js-kin-sdk error.
* tests added to all of those scenarios
* KinAccount unit tests was restructure to separate topics for better readability,
fixed retry in post requests (w/wo redirect), added and reorder tests with retry for better coverage.
#### Tests (Unit/Integ)
added tests for all new scenarios.
#### Documentation (Source/readme.md)
no changes.