### PR TITLE
run tests with node versions 8-12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
 language: node_js
-sudo: required
-services: docker
 
-node_js:
-  - "8"
+matrix:
+  include:
+  - node_js: 8
+  - node_js: 10
+  - node_js: 11
+  - node_js: 12
 
 script:
   - npm run build
   - npm run test
-
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
#### Main purpose (bug/feature/enhancement + description)
Run CI on all supported version (node >8), i.e. 8,10,11,12
#### Technical details
Use travis matrix to run each different node version as a job in parralel 
#### Tests (Unit/Integ)
Sure
#### Documentation (Source/readme.md)
N/A