### PR TITLE
re-fix whitelist API

### DIFF
--- a/scripts/src/index.ts
+++ b/scripts/src/index.ts
@@ -5,9 +5,16 @@ import {
 	PaymentListenerParams,
 	TransactionHistoryParams
 } from "./kinClient";
-import {CreateAccountParams, GetTransactionParams, KinAccount, SendKinParams} from "./kinAccount";
+import {
+	CreateAccountParams,
+	GetTransactionParams,
+	KinAccount,
+	SendKinParams,
+	WhitelistParams,
+	WhitelistPayload
+} from "./kinAccount";
 import {Environment} from "./environment";
-import {Address, TransactionId, WhitelistPayload} from "./types"
+import {Address, TransactionId} from "./types"
 import {
 	AccountData,
 	AssetType,
@@ -68,6 +75,7 @@ export {
 	CreateAccountParams,
 	SendKinParams,
 	WhitelistPayload,
+	WhitelistParams,
 	ChannelsPool,
 	Channel,
 	ChannelsPoolStatus,

--- a/scripts/src/kinAccount.ts
+++ b/scripts/src/kinAccount.ts
@@ -1,13 +1,13 @@
-import { AccountData, Balance } from "./blockchain/horizonModels";
-import { Server } from "@kinecosystem/kin-sdk";
-import { AccountDataRetriever } from "./blockchain/accountDataRetriever";
-import { TxSender } from "./blockchain/txSender";
-import { Address, TransactionId, WhitelistPayload } from "./types";
+import {AccountData, Balance} from "./blockchain/horizonModels";
+import {Server} from "@kinecosystem/kin-sdk";
+import {AccountDataRetriever} from "./blockchain/accountDataRetriever";
+import {TxSender} from "./blockchain/txSender";
+import {Address, TransactionId} from "./types";
 import * as config from "./config";
-import { KeyPair } from "./blockchain/keyPair";
-import { TransactionBuilder } from "./blockchain/transactionBuilder";
-import { Channel, ChannelsPool } from "./blockchain/channelsPool";
-import { IBlockchainInfoRetriever } from "./blockchain/blockchainInfoRetriever";
+import {KeyPair} from "./blockchain/keyPair";
+import {TransactionBuilder} from "./blockchain/transactionBuilder";
+import {Channel, ChannelsPool} from "./blockchain/channelsPool";
+import {IBlockchainInfoRetriever} from "./blockchain/blockchainInfoRetriever";
 
 export class KinAccount {
 	private readonly _keypair: KeyPair;
@@ -65,7 +65,7 @@ export class KinAccount {
 		return await this._txSender.submitTransaction(transactionBuilder);
 	}
 
-	whitelistTransaction(payload: WhitelistPayload): string {
+	whitelistTransaction(payload: WhitelistParams): string {
 		return this._txSender.whitelistTransaction(payload);
 	}
 }
@@ -134,3 +134,10 @@ export interface GetTransactionParams {
 	 */
 	channel?: Channel;
 }
+
+export interface WhitelistParams {
+	envelope: string;
+	networkId: string;
+};
+
+export type WhitelistPayload = WhitelistParams;

--- a/scripts/src/types.ts
+++ b/scripts/src/types.ts
@@ -1,13 +1,2 @@
 export type Address = string;
 export type TransactionId = string;
-
-export type WhitelistPayload =
-	{
-		envelope: string,
-		// backward compatibility, network_id is the correct one and aligns with python sdk
-		networkId: string
-	} |
-	{
-		envelope: string,
-		network_id: string
-	};

--- a/tests/src/kinAccount.unit.test.ts
+++ b/tests/src/kinAccount.unit.test.ts
@@ -11,7 +11,6 @@ import {
 } from "../../scripts/src/errors";
 import {Environment} from "../../scripts/src/environment";
 import {Memo, Network, Operation, Server} from "@kinecosystem/kin-sdk";
-import {WhitelistPayload} from "../../scripts/src/types";
 import {BlockchainInfoRetriever} from "../../scripts/src/blockchain/blockchainInfoRetriever";
 import {MEMO_LENGTH_ERROR} from "../../scripts/src/config";
 import CreateAccount = Operation.CreateAccount;
@@ -367,14 +366,37 @@ describe("KinAccount whitelist transaction", async () => {
 		initKinAccount();
 	});
 
-	test("whitelist transaction with networkId", () => {
-		const txPair: WhitelistPayload = {envelope: txPayload, networkId: Network.current().networkPassphrase()};
-		expect(kinAccount.whitelistTransaction(txPair)).toEqual(expectedWhitelistedPayload);
+	test("whitelist transaction with raw string", () => {
+		const json = {envelope: txPayload, network_id: Network.current().networkPassphrase()};
+		const rawString = JSON.stringify(json);
+		expect(kinAccount.whitelistTransaction(rawString as any)).toEqual(expectedWhitelistedPayload);
 	});
 
-	test("whitelist transaction with network_id", () => {
-		const txPair: WhitelistPayload = {envelope: txPayload, network_id: Network.current().networkPassphrase()};
-		expect(kinAccount.whitelistTransaction(txPair)).toEqual(expectedWhitelistedPayload);
+	test("whitelist transaction with raw string, missing network id, expect error", () => {
+		const json = {envelope: txPayload};
+		const rawString = JSON.stringify(json);
+		expect(() => kinAccount.whitelistTransaction(rawString as any))
+			.toThrow(TypeError);
+	});
+
+	test("whitelist transaction with raw string, missing envelope, expect error", () => {
+		const json = {network_id: Network.current().networkPassphrase()};
+		const rawString = JSON.stringify(json);
+		expect(() => kinAccount.whitelistTransaction(rawString as any))
+			.toThrow(TypeError);
+	});
+
+	test("whitelist transaction with raw string, invalid json, expect error", () => {
+		const rawString = JSON.stringify(txPayload);
+		expect(() => kinAccount.whitelistTransaction(rawString as any))
+			.toThrow(TypeError);
+	});
+
+	test("whitelist transaction, expect success", () => {
+		expect(kinAccount.whitelistTransaction({
+			envelope: txPayload,
+			networkId: Network.current().networkPassphrase()
+		})).toEqual(expectedWhitelistedPayload);
 	});
 
 	test("whitelist transaction, missing network id, expect error", () => {
@@ -383,7 +405,7 @@ describe("KinAccount whitelist transaction", async () => {
 	});
 
 	test("whitelist transaction, missing envelope, expect error", () => {
-		expect(() => kinAccount.whitelistTransaction({network_id: Network.current().networkPassphrase()} as any))
+		expect(() => kinAccount.whitelistTransaction({networkId: Network.current().networkPassphrase()} as any))
 			.toThrow(TypeError);
 	});
 


### PR DESCRIPTION

#### Main purpose (bug/feature/enhancement + description)
implement a different fix for https://github.com/kinecosystem/kin-sdk-node/pull/44:
Don't change API, API should get `networkId` as param to conform to existing
convention, for compatibility with python SDK, parse json from raw string
and expect "network_id" in this case (but don't expose it as API)
#### Technical details

#### Tests (Unit/Integ)
Added for all cases
#### Documentation (Source/readme.md)
no change